### PR TITLE
fix: dependency updates and corresponding astro hook alteration

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astro-graphql-plugin",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "type": "module",
   "exports": {
     ".": "./src/index.ts"
@@ -23,18 +23,18 @@
   },
   "devDependencies": {
     "@types/fs-extra": "^11.0.4",
-    "@types/marked": "5.0.2",
-    "astro": "^4.8.4",
-    "graphql": "16.8.1",
-    "typescript": "^5.4.5"
+    "@types/marked": "6.0.0",
+    "astro": "^5.1.8",
+    "graphql": "16.10.0",
+    "typescript": "^5.7.3"
   },
   "dependencies": {
-    "@graphql-tools/graphql-file-loader": "^8.0.1",
-    "@graphql-tools/json-file-loader": "^8.0.1",
-    "@graphql-tools/load": "^8.0.2",
-    "@graphql-tools/url-loader": "^8.0.2",
-    "fs-extra": "^11.2.0",
+    "@graphql-tools/graphql-file-loader": "^8.0.12",
+    "@graphql-tools/json-file-loader": "^8.0.11",
+    "@graphql-tools/load": "^8.0.12",
+    "@graphql-tools/url-loader": "^8.0.24",
+    "fs-extra": "^11.3.0",
     "github-slugger": "^2.0.0",
-    "marked": "12.0.2"
+    "marked": "15.0.6"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,9 @@ export default function GraphQL(options): AstroIntegration {
   return {
     name: "astro-graphql-plugin",
     hooks: {
-      "astro:build:start": async () => {
+      "astro:config:setup": async ({ command }) => {
+        // Ignore when running in preview mode.
+        if (command === 'preview') return
         const schema = await loadSchema(options.schema, {
           loaders: [
             new UrlLoader(),


### PR DESCRIPTION
Dependency bump plus changed the Astro hook that this plugin uses because the astro:build:start hook "runs after the Content Layer API is synced and cache some of its output, which means that the Markdown files generated will not be included in a production build until the site is built a second time." Comment attributed to https://github.com/HiDeoo/starlight-links-validator/issues/86#issuecomment-2604204509 

I believe this also fixes https://github.com/interledger/rafiki/issues/2938