### PR TITLE
chore: moved all 'devDependencies' to 'dependencies'

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astro-graphql-plugin",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "type": "module",
   "exports": {
     ".": "./src/index.ts"
@@ -21,13 +21,6 @@
     "type": "git",
     "url": "https://github.com/interledger/astro-graphql-plugin"
   },
-  "devDependencies": {
-    "@types/fs-extra": "^11.0.4",
-    "@types/marked": "6.0.0",
-    "astro": "^5.1.8",
-    "graphql": "16.10.0",
-    "typescript": "^5.7.3"
-  },
   "dependencies": {
     "@graphql-tools/graphql-file-loader": "^8.0.12",
     "@graphql-tools/json-file-loader": "^8.0.11",
@@ -35,6 +28,11 @@
     "@graphql-tools/url-loader": "^8.0.24",
     "fs-extra": "^11.3.0",
     "github-slugger": "^2.0.0",
-    "marked": "15.0.6"
+    "marked": "15.0.6",
+    "@types/fs-extra": "^11.0.4",
+    "@types/marked": "6.0.0",
+    "astro": "^5.1.8",
+    "graphql": "16.10.0",
+    "typescript": "^5.7.3"
   }
 }


### PR DESCRIPTION
Move all dependencies to "dependencies" to support TypeScript exports

Since we are exporting TypeScript files instead of precompiled JavaScript, all dependencies must be listed under "dependencies" rather than "devDependencies." This ensures that consumer projects, which are responsible for compiling the TypeScript, have access to all required modules.
